### PR TITLE
Beta (1.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.6
+
+**Improvements**
+ * Removes the Android write permissions requirement.
+ * Minor improvements in the example app.
+ * Now the exceptions are rethrown in case the user wants to handle them, despite that already being done in the plugin call.
+
 ## 1.3.5
 
 **Bug fix:** Fixes an issue that could prevent users to pick files from the iCloud Drive app, on versions below iOS 11. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.4+1
+
+**Rollback:** Removes a local dependency that shouldn't have been committed with `1.3.4` which would cause Android build to fail.
+
 ## 1.3.4
 
 **Bug fix:** Protects the `registrar.activity()` in the Android side of being accessed when it's `null`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5
+
+**Bug fix:** Fixes an issue that could prevent users to pick files from the iCloud Drive app, on versions below iOS 11. 
+
 ## 1.3.4+1
 
 **Rollback:** Removes a local dependency that shouldn't have been committed with `1.3.4` which would cause Android build to fail.
@@ -106,6 +110,6 @@
 
 ## 0.1.0
 
-* Initial realise.
+* Initial release.
 * Supports picking paths from files on local storage, cloud.
 * Supports picking paths from both gallery & camera due to [image_picker](https://pub.dartlang.org/packages/image_picker) dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.7
+
+**Rollback - Breaking change:** Re-adds runtime verification for external storage read permission. Don't forget to add the permission to the `AndroidManifest.xml` file as well. More info in the README file.
+**Bug fix:** Fixes a crash that could cause some Android API to crash when multiple files were selected from external storage.
+
 ## 1.3.6
 
 **Improvements**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.4
+
+**Bug fix:** Protects the `registrar.activity()` in the Android side of being accessed when it's `null`.
+
 ## 1.3.3
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,3 @@
-## 1.3.6
-
-**Improvements**
- * Removes the Android write permissions requirement.
- * Minor improvements in the example app.
- * Now the exceptions are rethrown in case the user wants to handle them, despite that already being done in the plugin call.
-
-## 1.3.5
-
-**Bug fix:** Fixes an issue that could prevent users to pick files from the iCloud Drive app, on versions below iOS 11. 
-
-## 1.3.4+1
-
-**Rollback:** Removes a local dependency that shouldn't have been committed with `1.3.4` which would cause Android build to fail.
-
-## 1.3.4
-
-**Bug fix:** Protects the `registrar.activity()` in the Android side of being accessed when it's `null`.
-
-## 1.3.3
-
-**Bug fixes**
- * Fixes an issue where sometimes a single file path was being returned as a `List` instead of `String`.
- * `requestCode` in Android intents are now restricted to 16 bits.
-
 ## 1.3.2
 
 **Bug fix:** Returns a `null` value in the `getFile()` when the picker is canceled.
@@ -117,6 +92,6 @@
 
 ## 0.1.0
 
-* Initial release.
+* Initial realise.
 * Supports picking paths from files on local storage, cloud.
 * Supports picking paths from both gallery & camera due to [image_picker](https://pub.dartlang.org/packages/image_picker) dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.3
+
+**Bug fixes**
+ * Fixes an issue where sometimes a single file path was being returned as a `List` instead of `String`.
+ * `requestCode` in Android intents are now restricted to 16 bits.
+
 ## 1.3.2
 
 **Bug fix:** Returns a `null` value in the `getFile()` when the picker is canceled.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A package that allows you to use a native file explorer to pick single or multip
 First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ```
-file_picker: ^1.3.4
+file_picker: ^1.3.4+1
 ```
 ### Android
 Add 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,11 @@ A package that allows you to use a native file explorer to pick single or multip
 First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ```
-file_picker: ^1.3.5
+file_picker: ^1.3.6
 ```
 ### Android
-Add 
-```
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-<uses-permission android:name="android.permission.INTERNET"/>
-```
-before `<application>` to your app's `AndroidManifest.xml` file. This is required due to file caching when a path is required from a remote file (eg. Google Drive).
+
+No aditional steps are required, you are good to go!
 
 ### iOS
 Based on the location of the files that you are willing to pick paths, you may need to add some keys to your iOS app's _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ String someFilePath = filePaths['fileName']; // Access a file path directly by i
 * [X] Load path from **any** 
 * [X] Create a `File` object from **any** selected file
 
+If you have any feature that you want to see in this package, please add it [here](https://github.com/miguelpruivo/plugins_flutter_file_picker/issues/99). 🎉
+
 ## Demo App
 
 ![Demo](https://github.com/miguelpruivo/plugins_flutter_file_picker/blob/master/example/example.gif)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![pub package](https://img.shields.io/pub/v/file_picker.svg)](https://pub.dartlang.org/packages/file_picker)
 [![Awesome Flutter](https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square)](https://github.com/Solido/awesome-flutter)
-[![Codemagic build status](https://api.codemagic.io/apps/5ce89f4a9b46f5000ca89638/5ce89f4a9b46f5000ca89637/status_badge.svg)](https://codemagic.io/apps/5ce89f4a9b46f5000ca89638/5ce89f4a9b46f5000ca89637/latest_build)
 
 # file_picker
 
@@ -11,12 +10,10 @@ A package that allows you to use a native file explorer to pick single or multip
 First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ```
-file_picker: ^1.3.6
+file_picker: ^1.3.2
 ```
-
 ### Android
-
-No aditional steps are required, you are good to go!
+Add `<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>` to your app `AndroidManifest.xml` file. This is required due to file caching when a path is required from a remote file (eg. Google Drive).
 
 ### iOS
 Based on the location of the files that you are willing to pick paths, you may need to add some keys to your iOS app's _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![pub package](https://img.shields.io/pub/v/file_picker.svg)](https://pub.dartlang.org/packages/file_picker)
 [![Awesome Flutter](https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square)](https://github.com/Solido/awesome-flutter)
+[![Codemagic build status](https://api.codemagic.io/apps/5ce89f4a9b46f5000ca89638/5ce89f4a9b46f5000ca89637/status_badge.svg)](https://codemagic.io/apps/5ce89f4a9b46f5000ca89638/5ce89f4a9b46f5000ca89637/latest_build)
 
 # file_picker
 
@@ -10,7 +11,7 @@ A package that allows you to use a native file explorer to pick single or multip
 First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ```
-file_picker: ^1.3.4+1
+file_picker: ^1.3.5
 ```
 ### Android
 Add 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://f
 file_picker: ^1.3.3
 ```
 ### Android
-Add `<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>` to your app `AndroidManifest.xml` file. This is required due to file caching when a path is required from a remote file (eg. Google Drive).
+Add 
+```
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+<uses-permission android:name="android.permission.INTERNET"/>
+```
+before `<application>` to your app's `AndroidManifest.xml` file. This is required due to file caching when a path is required from a remote file (eg. Google Drive).
 
 ### iOS
 Based on the location of the files that you are willing to pick paths, you may need to add some keys to your iOS app's _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A package that allows you to use a native file explorer to pick single or multip
 First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ```
-file_picker: ^1.3.3
+file_picker: ^1.3.4
 ```
 ### Android
 Add 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A package that allows you to use a native file explorer to pick single or multip
 First, add  *file_picker*  as a dependency in [your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ```
-file_picker: ^1.3.2
+file_picker: ^1.3.3
 ```
 ### Android
 Add `<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>` to your app `AndroidManifest.xml` file. This is required due to file caching when a path is required from a remote file (eg. Google Drive).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ file_picker: ^1.3.6
 ```
 ### Android
 
-No aditional steps are required, you are good to go!
+Add
+```
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+```
+before `<application>` to your app's `AndroidManifest.xml` file. This is required to access files from external storage.
+
 
 ### iOS
 Based on the location of the files that you are willing to pick paths, you may need to add some keys to your iOS app's _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -185,7 +185,12 @@ public class FilePickerPlugin implements MethodCallHandler {
     intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultipleSelection);
     intent.addCategory(Intent.CATEGORY_OPENABLE);
 
-    instance.activity().startActivityForResult(intent, REQUEST_CODE);
+    if(intent.resolveActivity(instance.activity().getPackageManager()) != null) {
+      instance.activity().startActivityForResult(intent, REQUEST_CODE);
+    } else {
+      Log.e(TAG, "Can't find a valid activity to handle the request. Make sure you've a file explorer installed.");
+      result.error(TAG, "Can't handle the provided file type." ,null);
+    }
   }
 
 }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -31,9 +31,6 @@ public class FileUtils {
             if (isGooglePhotosUri(uri)) {
                 return uri.getLastPathSegment();
             }
-            if (isDropBoxUri(uri)) {
-                return null;
-            }
             return getDataColumn(context, uri, null, null);
         } else if ("file".equalsIgnoreCase(uri.getScheme())) {
             return uri.getPath();
@@ -108,9 +105,11 @@ public class FileUtils {
             }
         } else if ("content".equalsIgnoreCase(uri.getScheme())) {
             Log.e(TAG, "NO DOCUMENT URI - CONTENT");
-            if (isGooglePhotosUri(uri))
+            if (isGooglePhotosUri(uri)) {
                 return uri.getLastPathSegment();
-
+            } else if (isDropBoxUri(uri)) {
+                return null;
+            }
             return getDataColumn(context, uri, null, null);
         } else if ("file".equalsIgnoreCase(uri.getScheme())) {
             Log.e(TAG, "No DOCUMENT URI - FILE");

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -19,10 +19,6 @@ import java.io.InputStream;
 
 import io.flutter.plugin.common.MethodChannel;
 
-/**
- * Credits to NiRRaNjAN from utils extracted of in.gauriinfotech.commons;.
- **/
-
 public class FileUtils {
 
     private static final String TAG = "FilePickerUtils";
@@ -34,6 +30,9 @@ public class FileUtils {
         } else if ("content".equalsIgnoreCase(uri.getScheme())) {
             if (isGooglePhotosUri(uri)) {
                 return uri.getLastPathSegment();
+            }
+            if (isDropBoxUri(uri)) {
+                return null;
             }
             return getDataColumn(context, uri, null, null);
         } else if ("file".equalsIgnoreCase(uri.getScheme())) {
@@ -212,6 +211,9 @@ public class FileUtils {
             return cloudFile;
     }
 
+    private static boolean isDropBoxUri(Uri uri) {
+        return "com.dropbox.android.FileCache".equals(uri.getAuthority());
+    }
 
     private static boolean isExternalStorageDocument(Uri uri) {
         return "com.android.externalstorage.documents".equals(uri.getAuthority());

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -175,11 +175,12 @@ public class FileUtils {
 
     public static String getUriFromRemote(Context context, Uri uri, MethodChannel.Result result) {
 
+        Log.i(TAG, "Caching file from remote/external URI");
         FileOutputStream fos = null;
-        String cloudFile = context.getCacheDir().getAbsolutePath() + "/" + FileUtils.getFileName(uri, context);
+        String externalFile = context.getCacheDir().getAbsolutePath() + "/" + FileUtils.getFileName(uri, context);
 
             try {
-                fos = new FileOutputStream(cloudFile);
+                fos = new FileOutputStream(externalFile);
                 try {
                     BufferedOutputStream out = new BufferedOutputStream(fos);
                     InputStream in = context.getContentResolver().openInputStream(uri);
@@ -206,8 +207,8 @@ public class FileUtils {
                 return null;
             }
 
-            Log.i(TAG, "Remote file loaded and cached at:" + cloudFile);
-            return cloudFile;
+            Log.i(TAG, "File loaded and cached at:" + externalFile);
+            return externalFile;
     }
 
     private static boolean isDropBoxUri(Uri uri) {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/> -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,10 +31,12 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       try {
         if (_multiPick) {
           _path = null;
-          _paths = await FilePicker.getMultiFilePath(type: _pickingType, fileExtension: _extension);
+          _paths = await FilePicker.getMultiFilePath(
+              type: _pickingType, fileExtension: _extension);
         } else {
           _paths = null;
-          _path = await FilePicker.getFilePath(type: _pickingType, fileExtension: _extension);
+          _path = await FilePicker.getFilePath(
+              type: _pickingType, fileExtension: _extension);
         }
       } on PlatformException catch (e) {
         print("Unsupported operation" + e.toString());
@@ -42,7 +44,9 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       if (!mounted) return;
 
       setState(() {
-        _fileName = _path != null ? _path.split('/').last : _paths != null ? _paths.keys.toString() : '...';
+        _fileName = _path != null
+            ? _path.split('/').last
+            : _paths != null ? _paths.keys.toString() : '...';
       });
     }
   }
@@ -102,7 +106,8 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
                           maxLength: 15,
                           autovalidate: true,
                           controller: _controller,
-                          decoration: InputDecoration(labelText: 'File extension'),
+                          decoration:
+                              InputDecoration(labelText: 'File extension'),
                           keyboardType: TextInputType.text,
                           textCapitalization: TextCapitalization.none,
                           validator: (value) {
@@ -112,6 +117,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
                               return 'Invalid format';
                             }
                             _hasValidMime = true;
+                            return null;
                           },
                         )
                       : new Container(),
@@ -119,8 +125,10 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
                 new ConstrainedBox(
                   constraints: BoxConstraints.tightFor(width: 200.0),
                   child: new SwitchListTile.adaptive(
-                    title: new Text('Pick multiple files', textAlign: TextAlign.right),
-                    onChanged: (bool value) => setState(() => _multiPick = value),
+                    title: new Text('Pick multiple files',
+                        textAlign: TextAlign.right),
+                    onChanged: (bool value) =>
+                        setState(() => _multiPick = value),
                     value: _multiPick,
                   ),
                 ),
@@ -132,29 +140,40 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
                   ),
                 ),
                 new Builder(
-                  builder: (BuildContext context) => _path != null || _paths != null
-                      ? new Container(
-                          padding: const EdgeInsets.only(bottom: 30.0),
-                          height: MediaQuery.of(context).size.height * 0.50,
-                          child: new Scrollbar(
-                              child: new ListView.separated(
-                            itemCount: _paths != null && _paths.isNotEmpty ? _paths.length : 1,
-                            itemBuilder: (BuildContext context, int index) {
-                              final bool isMultiPath = _paths != null && _paths.isNotEmpty;
-                              final String name = 'File $index: ' + (isMultiPath ? _paths.keys.toList()[index] : _fileName ?? '...');
-                              final path = isMultiPath ? _paths.values.toList()[index].toString() : _path;
+                  builder: (BuildContext context) =>
+                      _path != null || _paths != null
+                          ? new Container(
+                              padding: const EdgeInsets.only(bottom: 30.0),
+                              height: MediaQuery.of(context).size.height * 0.50,
+                              child: new Scrollbar(
+                                  child: new ListView.separated(
+                                itemCount: _paths != null && _paths.isNotEmpty
+                                    ? _paths.length
+                                    : 1,
+                                itemBuilder: (BuildContext context, int index) {
+                                  final bool isMultiPath =
+                                      _paths != null && _paths.isNotEmpty;
+                                  final String name = 'File $index: ' +
+                                      (isMultiPath
+                                          ? _paths.keys.toList()[index]
+                                          : _fileName ?? '...');
+                                  final path = isMultiPath
+                                      ? _paths.values.toList()[index].toString()
+                                      : _path;
 
-                              return new ListTile(
-                                title: new Text(
-                                  name,
-                                ),
-                                subtitle: new Text(path),
-                              );
-                            },
-                            separatorBuilder: (BuildContext context, int index) => new Divider(),
-                          )),
-                        )
-                      : new Container(),
+                                  return new ListTile(
+                                    title: new Text(
+                                      name,
+                                    ),
+                                    subtitle: new Text(path),
+                                  );
+                                },
+                                separatorBuilder:
+                                    (BuildContext context, int index) =>
+                                        new Divider(),
+                              )),
+                            )
+                          : new Container(),
                 ),
               ],
             ),

--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -23,7 +23,8 @@ class FilePicker {
   /// A [fileExtension] can be provided to filter the picking results.
   /// If provided, it will be use the `FileType.CUSTOM` for that [fileExtension].
   /// If not, `FileType.ANY` will be used and any combination of files can be multi picked at once.
-  static Future<Map<String, String>> getMultiFilePath({FileType type = FileType.ANY, String fileExtension}) async =>
+  static Future<Map<String, String>> getMultiFilePath(
+          {FileType type = FileType.ANY, String fileExtension}) async =>
       await _getPath(_handleType(type, fileExtension), true);
 
   /// Returns an absolute file path from the calling platform.
@@ -31,15 +32,18 @@ class FilePicker {
   /// A [type] must be provided to filter the picking results.
   /// Can be used a custom file type with `FileType.CUSTOM`. A [fileExtension] must be provided (e.g. PDF, SVG, etc.)
   /// Defaults to `FileType.ANY` which will display all file types.
-  static Future<String> getFilePath({FileType type = FileType.ANY, String fileExtension}) async =>
+  static Future<String> getFilePath(
+          {FileType type = FileType.ANY, String fileExtension}) async =>
       await _getPath(_handleType(type, fileExtension), false);
 
   /// Returns a `File` object from the selected file path.
   ///
   /// This is an utility method that does the same of `getFilePath()` but saving some boilerplate if
   /// you are planing to create a `File` for the returned path.
-  static Future<File> getFile({FileType type = FileType.ANY, String fileExtension}) async {
-    final String filePath = await _getPath(_handleType(type, fileExtension), false);
+  static Future<File> getFile(
+      {FileType type = FileType.ANY, String fileExtension}) async {
+    final String filePath =
+        await _getPath(_handleType(type, fileExtension), false);
     return filePath != null ? File(filePath) : null;
   }
 
@@ -50,14 +54,16 @@ class FilePicker {
         if (result is String) {
           result = [result];
         }
-        return Map<String, String>.fromIterable(result, key: (path) => path.split('/').last, value: (path) => path);
+        return Map<String, String>.fromIterable(result,
+            key: (path) => path.split('/').last, value: (path) => path);
       }
       return result;
     } on PlatformException catch (e) {
       print('[$_tag] Platform exception: $e');
       rethrow;
     } catch (e) {
-      print('[$_tag] Unsupported operation. Method not found. The exception thrown was: $e');
+      print(
+          '[$_tag] Unsupported operation. Method not found. The exception thrown was: $e');
       rethrow;
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
 author: Miguel Ruivo <miguel@miguelruivo.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.4+1
+version: 1.3.5
 
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
 author: Miguel Ruivo <miguel@miguelruivo.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.6
+version: 1.3.7
 
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
 author: Miguel Ruivo <miguel@miguelruivo.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.3
+version: 1.3.4
 
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,9 @@
 name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
-author: Miguel Ruivo <miguel@miguelruivo.com>
+author: Miguel Ruivo <miguelpruivo@outlook.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.6
+version: 1.3.2
+
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
 author: Miguel Ruivo <miguel@miguelruivo.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.4
+version: 1.3.4+1
 
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
-author: Miguel Ruivo <miguelpruivo@outlook.com>
+author: Miguel Ruivo <miguel@miguelruivo.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.2
+version: 1.3.3
 
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extensions filtering support.
 author: Miguel Ruivo <miguel@miguelruivo.com>
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.3.5
+version: 1.3.6
 
 
 dependencies:


### PR DESCRIPTION
## 1.3.7

**Rollback - Breaking change:** Re-adds runtime verification for external storage read permission. Don't forget to add the permission to the `AndroidManifest.xml` file as well. More info in the README file.
**Bug fix:** Fixes a crash that could cause some Android API to crash when multiple files were selected from external storage.